### PR TITLE
支持 ansible 并发发布文件、执行远程命令

### DIFF
--- a/components/Ansible.php
+++ b/components/Ansible.php
@@ -51,7 +51,7 @@ class Ansible extends Command
 
         $command = sprintf('ansible %s -u %s -m ping -i %s -f %d -T %d',
             escapeshellarg($ansibleHosts),
-            escapeshellarg($this->config->release_user),
+            escapeshellarg($this->getConfig()->release_user),
             escapeshellarg(Project::getAnsibleHostsFile()),
             $this->ansibleFork,
             $this->ansibleTimeout);
@@ -92,7 +92,7 @@ class Ansible extends Command
 
         $localCommand = sprintf('ansible %s -u %s -m raw -a %s -i %s -f %d -T %d',
             escapeshellarg($ansibleHosts),
-            escapeshellarg($this->config->release_user),
+            escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
             escapeshellarg(Project::getAnsibleHostsFile()),
             $this->ansibleFork,
@@ -116,7 +116,7 @@ class Ansible extends Command
 
         $localCommand = sprintf('ansible %s -u %s -m command -a %s -i %s -f %d -T %d',
             escapeshellarg($ansibleHosts),
-            escapeshellarg($this->config->release_user),
+            escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
             escapeshellarg(Project::getAnsibleHostsFile()),
             $this->ansibleFork,
@@ -140,7 +140,7 @@ class Ansible extends Command
 
         $localCommand = sprintf('ansible %s -u %s -m shell -a %s -i %s -f %d -T %d',
             escapeshellarg($ansibleHosts),
-            escapeshellarg($this->config->release_user),
+            escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
             escapeshellarg(Project::getAnsibleHostsFile()),
             $this->ansibleFork,
@@ -164,7 +164,7 @@ class Ansible extends Command
 
         $localCommand = sprintf('ansible %s -u %s -m script -a %s -i %s -f %d -T %d',
             escapeshellarg($ansibleHosts),
-            escapeshellarg($this->config->release_user),
+            escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($shellFile),
             escapeshellarg(Project::getAnsibleHostsFile()),
             $this->ansibleFork,

--- a/components/Ansible.php
+++ b/components/Ansible.php
@@ -27,6 +27,13 @@ class Ansible extends Command
     public $ansibleTimeout = 600;
 
     /**
+     * Ansible 调用SSH的附加参数
+     *
+     * @var string
+     */
+    public $ansibleSshArgs = 'ANSIBLE_SSH_ARGS=\'-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=false\'';
+
+    /**
      * 测试 ansible 命令是否可用
      *
      * @return bool|int
@@ -49,7 +56,8 @@ class Ansible extends Command
 
         $ansibleHosts = $this->_getAnsibleHosts($hosts);
 
-        $command = sprintf('ansible %s -u %s -m ping -i %s -f %d -T %d',
+        $command = sprintf('%s ansible %s -u %s -m ping -i %s -f %d -T %d -vvv',
+            $this->ansibleSshArgs,
             escapeshellarg($ansibleHosts),
             escapeshellarg($this->getConfig()->release_user),
             escapeshellarg(Project::getAnsibleHostsFile()),
@@ -90,7 +98,8 @@ class Ansible extends Command
 
         $ansibleHosts = $this->_getAnsibleHosts($hosts);
 
-        $localCommand = sprintf('ansible %s -u %s -m raw -a %s -i %s -f %d -T %d',
+        $localCommand = sprintf('%s ansible %s -u %s -m raw -a %s -i %s -f %d -T %d',
+            $this->ansibleSshArgs,
             escapeshellarg($ansibleHosts),
             escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
@@ -114,7 +123,8 @@ class Ansible extends Command
 
         $ansibleHosts = $this->_getAnsibleHosts($hosts);
 
-        $localCommand = sprintf('ansible %s -u %s -m command -a %s -i %s -f %d -T %d',
+        $localCommand = sprintf('%s ansible %s -u %s -m command -a %s -i %s -f %d -T %d',
+            $this->ansibleSshArgs,
             escapeshellarg($ansibleHosts),
             escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
@@ -138,7 +148,8 @@ class Ansible extends Command
 
         $ansibleHosts = $this->_getAnsibleHosts($hosts);
 
-        $localCommand = sprintf('ansible %s -u %s -m shell -a %s -i %s -f %d -T %d',
+        $localCommand = sprintf('%s ansible %s -u %s -m shell -a %s -i %s -f %d -T %d',
+            $this->ansibleSshArgs,
             escapeshellarg($ansibleHosts),
             escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($remoteCommand),
@@ -162,7 +173,8 @@ class Ansible extends Command
 
         $ansibleHosts = $this->_getAnsibleHosts($hosts);
 
-        $localCommand = sprintf('ansible %s -u %s -m script -a %s -i %s -f %d -T %d',
+        $localCommand = sprintf('%s ansible %s -u %s -m script -a %s -i %s -f %d -T %d',
+            $this->ansibleSshArgs,
             escapeshellarg($ansibleHosts),
             escapeshellarg($this->getConfig()->release_user),
             escapeshellarg($shellFile),

--- a/components/Ansible.php
+++ b/components/Ansible.php
@@ -1,0 +1,70 @@
+<?php
+/* *****************************************************************
+ * @Author: wushuiyong
+ * @Created Time : 五  7/31 22:21:23 2015
+ *
+ * @File Name: command/Sync.php
+ * @Description:
+ * *****************************************************************/
+namespace app\components;
+
+use app\models\Project;
+
+class Ansible extends Command
+{
+
+    /**
+     * Ansible Fork
+     * @var int
+     */
+    public $ansibleFork = 10;
+
+    /**
+     * 测试 ansible 命令是否可用
+     *
+     * @return bool|int
+     */
+    public function test()
+    {
+
+        $command = 'ansible --version';
+
+        return $this->runLocalCommand($command);
+    }
+
+    /**
+     * ping 测试 ansible 连接远程主机是否正确
+     *
+     * @param array $hosts
+     */
+    public function ping($hosts = [])
+    {
+
+        $ansibleHosts = $this->_getAnsibleHosts($hosts);
+
+        $command = sprintf('ansible %s -m ping -i %s -f %d',
+            escapeshellarg($ansibleHosts),
+            escapeshellarg(Project::getAnsibleHostsFile()),
+            $this->ansibleFork);
+
+        return $this->runLocalCommand($command);
+    }
+
+    /**
+     * 根据传入的 hosts 数组 生成 ansible 命令需要的 hosts 桉树
+     * @param array $hosts
+     * @return string
+     */
+    protected function _getAnsibleHosts($hosts = [])
+    {
+
+        if ($hosts) {
+            $ansibleHosts = implode(':', $hosts);
+        } else {
+            $ansibleHosts = 'all';
+        }
+
+        return $ansibleHosts;
+    }
+
+}

--- a/components/Command.php
+++ b/components/Command.php
@@ -86,16 +86,19 @@ class Command {
      */
     final public function runRemoteCommand($command) {
         $this->log = '';
-        $needTTY = ' -T ';
+        $needTTY = '-T';
 
         foreach (GlobalHelper::str2arr($this->getConfig()->hosts) as $remoteHost) {
-            $localCommand = 'ssh ' . $needTTY . ' -p ' . $this->getHostPort($remoteHost)
-                . ' -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '
-                . $this->getConfig()->release_user . '@'
-                . $this->getHostName($remoteHost);
-            $remoteCommand = str_replace('"', '\\"', trim($command));
-            $localCommand .= ' " ' . $remoteCommand . ' " ';
-            static::log('Run remote command ' . $remoteCommand);
+
+            $localCommand = sprintf('ssh %s -p %d -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=false %s@%s %s',
+                $needTTY,
+                $this->getHostPort($remoteHost),
+                escapeshellarg($this->getConfig()->release_user),
+                escapeshellarg($this->getHostName($remoteHost)),
+                escapeshellarg($command)
+            );
+
+            static::log('Run remote command ' . $command);
 
             $log = $this->log;
             $this->status = $this->runLocalCommand($localCommand);

--- a/components/Folder.php
+++ b/components/Folder.php
@@ -69,13 +69,13 @@ class Folder extends Ansible {
     public function syncFiles($remoteHost, $version) {
         $excludes = GlobalHelper::str2arr($this->getConfig()->excludes);
 
-        $command = sprintf('rsync -avzq --rsh="ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p %s" %s %s %s%s:%s',
+        $command = sprintf('rsync -avzq --rsh="ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=false -p %d" %s %s %s@%s:%s',
             $this->getHostPort($remoteHost),
             $this->excludes($excludes),
-            rtrim(Project::getDeployWorkspace($version), '/') . '/',
-            $this->getConfig()->release_user . '@',
-            $this->getHostName($remoteHost),
-            Project::getReleaseVersionDir($version));
+            escapeshellarg(rtrim(Project::getDeployWorkspace($version), '/') . '/'),
+            escapeshellarg($this->getConfig()->release_user),
+            escapeshellarg($this->getHostName($remoteHost)),
+            escapeshellarg(Project::getReleaseVersionDir($version)));
 
         return $this->runLocalCommand($command);
     }

--- a/components/Folder.php
+++ b/components/Folder.php
@@ -86,13 +86,13 @@ class Folder extends Ansible {
      * ansible 不支持 rsync模块, 改用宿主机 tar 打包, ansible 并发传输到目标机临时目录, 目标机解压
      *
      * @param $version
+     * @param string $files 相对仓库文件/目录路径, 空格分割
      * @param array $remoteHosts
      */
-    public function copyFilesByAnsible($version, $remoteHosts = []) {
+    public function copyFiles($version, $files = '*', $remoteHosts = []) {
 
         // 1. 打包
         $excludes = GlobalHelper::str2arr($this->getConfig()->excludes);
-        $files = '*';
         $packagePath = Project::getDeployPackagePath($version);
         $packageCommand = sprintf('cd %s && tar %s --preserve-permissions -czf %s %s',
             escapeshellarg(rtrim(Project::getDeployWorkspace($version), '/') . '/'),

--- a/components/Folder.php
+++ b/components/Folder.php
@@ -10,7 +10,7 @@ namespace app\components;
 
 use app\models\Project;
 
-class Folder extends Command {
+class Folder extends Ansible {
 
 
     /**
@@ -50,7 +50,14 @@ class Folder extends Command {
         }
         $command = join(' && ', $cmd);
 
-        return $this->runRemoteCommand($command);
+        if (Project::getAnsibleStatus()) {
+            // ansible 并发执行远程命令
+            return $this->runRemoteCommandByAnsibleShell($command);
+        } else {
+            // ssh 循环执行远程命令
+            return $this->runRemoteCommand($command);
+        }
+
     }
 
     /**
@@ -102,7 +109,12 @@ class Folder extends Command {
         $cmd[] = "test -f /usr/bin/md5sum && md5sum {$file}";
         $command = join(' && ', $cmd);
 
-        return $this->runRemoteCommand($command);
+        if (Project::getAnsibleStatus()) {
+            // ansible 并发执行远程命令
+            return $this->runRemoteCommandByAnsibleShell($command);
+        } else {
+            return $this->runRemoteCommand($command);
+        }
     }
 
     /**
@@ -147,5 +159,6 @@ class Folder extends Command {
         $command = join(' && ', $cmd);
         return $this->runLocalCommand($command);
     }
+
 }
 

--- a/components/Task.php
+++ b/components/Task.php
@@ -75,12 +75,17 @@ class Task extends Ansible {
      */
     public function cleanUpReleasesVersion() {
 
+        $ansibleStatus = Project::getAnsibleStatus();
+
         $cmd[] = sprintf('cd %s', Project::getReleaseVersionDir());
+        if ($ansibleStatus) {
+            $cmd[] = sprintf('rm -f %s/*.tar.gz', rtrim(Project::getReleaseVersionDir(), '/'));
+        }
         $cmd[] = sprintf('ls -1 | sort -r | awk \'FNR > %d  {printf("rm -rf %%s\n", $0);}\' | bash', $this->config->keep_version_num);
 
         $command = join(' && ', $cmd);
 
-        if (Project::getAnsibleStatus()) {
+        if ($ansibleStatus) {
             // ansible 并发执行远程命令
             return $this->runRemoteCommandByAnsibleShell($command);
         } else {

--- a/components/Task.php
+++ b/components/Task.php
@@ -8,7 +8,6 @@
  * *****************************************************************/
 namespace app\components;
 
-
 use app\models\Project;
 
 class Task extends Command {
@@ -41,7 +40,6 @@ class Task extends Command {
         $command = join(' && ', $cmd);
         return $this->runLocalCommand($command);
     }
-
 
     /**
      * post-deploy部署代码后置触发任务

--- a/components/Task.php
+++ b/components/Task.php
@@ -10,7 +10,7 @@ namespace app\components;
 
 use app\models\Project;
 
-class Task extends Command {
+class Task extends Ansible {
 
     /**
      * pre-deploy部署代码前置触发任务
@@ -74,11 +74,18 @@ class Task extends Command {
      * 设置了版本保留数量，超出了设定值，则删除老版本
      */
     public function cleanUpReleasesVersion() {
+
         $cmd[] = sprintf('cd %s', Project::getReleaseVersionDir());
-        $cmd[] = 'ls -1|sort -r|awk \'FNR > ' . $this->config->keep_version_num . ' {printf("rm -rf %s\n", \$0);}\' | bash ';
+        $cmd[] = sprintf('ls -1 | sort -r | awk \'FNR > %d  {printf("rm -rf %%s\n", $0);}\' | bash', $this->config->keep_version_num);
 
         $command = join(' && ', $cmd);
-        return $this->runRemoteCommand($command);
+
+        if (Project::getAnsibleStatus()) {
+            // ansible 并发执行远程命令
+            return $this->runRemoteCommandByAnsibleShell($command);
+        } else {
+            return $this->runRemoteCommand($command);
+        }
     }
 
     /**
@@ -121,8 +128,16 @@ class Task extends Command {
      * @return mixed
      */
     public function runRemoteTaskCommandPackage($tasks) {
+
         $task = join(' && ', $tasks);
-        return $this->runRemoteCommand($task);
+
+        if (Project::getAnsibleStatus()) {
+            // ansible 并发执行远程命令
+            return $this->runRemoteCommandByAnsibleShell($task);
+        } else {
+            return $this->runRemoteCommand($task);
+        }
+
     }
 
 }

--- a/config/params.php
+++ b/config/params.php
@@ -3,6 +3,7 @@
  * 亲，为方便大家，已经把必须修改为自己配置的选项已经带上*****了
  * 此配置为测试配置，如果你不想消息泄露，请尽快修改为自己的邮箱smtp
  */
+
 return [
     'user.passwordResetTokenExpire' => 3600,
     'user.emailConfirmationTokenExpire' => 43200, // 5 days有效
@@ -15,7 +16,7 @@ return [
     // *******操作日志目录*******
     'log.dir' => '/tmp/walle/',
     // *******Ansible Hosts 主机列表目录*******
-    'ansible_hosts.dir' => '/tmp/walle/',
+    'ansible_hosts.dir' => realpath(__DIR__ . '/../runtime') . '/ansible_hosts/',
     // *******指定公司邮箱后缀*******
     'mail-suffix' => [
         '*', # 支持多个

--- a/config/params.php
+++ b/config/params.php
@@ -14,6 +14,8 @@ return [
 
     // *******操作日志目录*******
     'log.dir' => '/tmp/walle/',
+    // *******Ansible Hosts 主机列表目录*******
+    'ansible_hosts.dir' => '/tmp/walle/',
     // *******指定公司邮箱后缀*******
     'mail-suffix' => [
         '*', # 支持多个

--- a/console/WalleController.php
+++ b/console/WalleController.php
@@ -8,7 +8,7 @@
 * *****************************************************************/
 
 namespace app\console;
- 
+
 use yii;
 use yii\console\Controller;
 use yii\helpers\Console;
@@ -82,12 +82,13 @@ class WalleController extends Controller {
      */
     protected function createDir() {
         $mkdirPaths = [
-            yii::$app->params['log.dir']
+            yii::$app->params['log.dir'],
+            yii::$app->params['ansible_hosts.dir']
         ];
         foreach ($mkdirPaths as $path) {
             $path = Yii::getAlias($path);
             Console::output("mkdiring dir: {$path}");
-            @mkdir($path, 0755);
+            @mkdir($path, 0755, true);
         }
     }
 
@@ -96,6 +97,7 @@ class WalleController extends Controller {
      */
     protected function setWritable() {
         $this->writablePaths[] = yii::$app->params['log.dir'];
+        $this->writablePaths[] = yii::$app->params['ansible_hosts.dir'];
         foreach ($this->writablePaths as $writable) {
             $writable = Yii::getAlias($writable);
             Console::output("Setting writable: {$writable}");
@@ -113,6 +115,5 @@ class WalleController extends Controller {
             @chmod($executable, 0755);
         }
     }
-
 
 }

--- a/controllers/ConfController.php
+++ b/controllers/ConfController.php
@@ -152,6 +152,12 @@ class ConfController extends Controller
         $copy->load($project->getAttributes(), '');
 
         if (!$copy->save()) throw new \Exception(yii::t('conf', 'copy failed'));
+
+        // 删除ansible配置文件
+        if ($project->ansible) {
+            copy(Project::getAnsibleHostsFile($project->id), Project::getAnsibleHostsFile($copy->id));
+        }
+
         $this->renderJson([]);
     }
 
@@ -163,7 +169,14 @@ class ConfController extends Controller
      */
     public function actionDelete($projectId) {
         $project = $this->findModel($projectId);
+
         if (!$project->delete()) throw new \Exception(yii::t('w', 'delete failed'));
+
+        // 删除ansible配置文件
+        if ($project->ansible) {
+            unlink(Project::getAnsibleHostsFile($project->id));
+        }
+
         $this->renderJson([]);
     }
 
@@ -240,7 +253,7 @@ class ConfController extends Controller
             return true;
         }
 
-        $filePath = Project::getAnsibleHostsFile();
+        $filePath = Project::getAnsibleHostsFile($project->id);
         $ret = @file_put_contents($filePath, $project->hosts);
         if (!$ret) {
             throw new \Exception(yii::t('conf', 'ansible hosts save error', ['path' => $filePath]));
@@ -248,4 +261,5 @@ class ConfController extends Controller
 
         return true;
     }
+
 }

--- a/controllers/WalleController.php
+++ b/controllers/WalleController.php
@@ -106,7 +106,7 @@ class WalleController extends Controller {
 
             // 可回滚的版本设置
             $this->_enableRollBack();
-            
+
             // 记录当前线上版本（软链）回滚则是回滚的版本，上线为新版本
             $this->conf->version = $this->task->link_id;
             $this->conf->save();
@@ -187,6 +187,23 @@ class WalleController extends Controller {
         } catch (\Exception $e) {
             $code = -1;
             $log[] = yii::t('walle', 'target server sys error', [
+                'error' => $e->getMessage()
+            ]);
+        }
+
+        // 检测 ansible 是否安装
+        try {
+            if ($project->ansible) {
+                $command = 'ansible --version';
+                $ret = $this->walleTask->runLocalCommand($command);
+                if (!$ret) {
+                    $code = -1;
+                    $log[] = yii::t('walle', 'hosted server ansible error');
+                }
+            }
+        } catch (\Exception $e) {
+            $code = -1;
+            $log[] = yii::t('walle', 'hosted server sys error', [
                 'error' => $e->getMessage()
             ]);
         }

--- a/controllers/WalleController.php
+++ b/controllers/WalleController.php
@@ -173,31 +173,6 @@ class WalleController extends Controller {
             ]);
         }
 
-        // 权限与免密码登录检测
-        $this->walleTask = new WalleTask($project);
-        try {
-            $command = sprintf('mkdir -p %s', Project::getReleaseVersionDir('detection'));
-            $ret = $this->walleTask->runRemoteTaskCommandPackage([$command]);
-            if (!$ret) {
-                $code = -1;
-                $log[] = yii::t('walle', 'target server error', [
-                    'local_user'  => getenv("USER"),
-                    'remote_user' => $project->release_user,
-                    'path'        => $project->release_to,
-                    'error'       => $this->walleTask->getExeLog(),
-                ]);
-            }
-            // 清除
-            $command = sprintf('rm -rf %s', Project::getReleaseVersionDir('detection'));
-            $this->walleTask->runRemoteTaskCommandPackage([$command]);
-        } catch (\Exception $e) {
-            $code = -1;
-            $log[] = yii::t('walle', 'target server sys error', [
-                'error' => $e->getMessage()
-            ]);
-        }
-
-
         try {
             if ($project->ansible) {
                 $this->ansible = new Ansible($project);
@@ -223,6 +198,30 @@ class WalleController extends Controller {
             ]);
         }
 
+        // 权限与免密码登录检测
+        $this->walleTask = new WalleTask($project);
+        try {
+            $command = sprintf('mkdir -p %s', Project::getReleaseVersionDir('detection'));
+            $ret = $this->walleTask->runRemoteTaskCommandPackage([$command]);
+            if (!$ret) {
+                $code = -1;
+                $log[] = yii::t('walle', 'target server error', [
+                    'local_user'  => getenv("USER"),
+                    'remote_user' => $project->release_user,
+                    'path'        => $project->release_to,
+                    'error'       => $this->walleTask->getExeLog(),
+                ]);
+            }
+            // 清除
+            $command = sprintf('rm -rf %s', Project::getReleaseVersionDir('detection'));
+            $this->walleTask->runRemoteTaskCommandPackage([$command]);
+        } catch (\Exception $e) {
+            $code = -1;
+            $log[] = yii::t('walle', 'target server sys error', [
+                'error' => $e->getMessage()
+            ]);
+        }
+
         // task 检测todo...
 
         if ($code === 0) {
@@ -230,7 +229,6 @@ class WalleController extends Controller {
         }
         $this->renderJson(join("<br>", $log), $code);
     }
-
 
     /**
      * 获取线上文件md5

--- a/controllers/WalleController.php
+++ b/controllers/WalleController.php
@@ -248,7 +248,7 @@ class WalleController extends Controller {
         $this->walleFolder->getFileMd5($file);
         $log = $this->walleFolder->getExeLog();
 
-        $this->renderJson(join("<br>", explode(PHP_EOL, $log)));
+        $this->renderJson(nl2br($log));
     }
 
     /**

--- a/messages/en/conf.php
+++ b/messages/en/conf.php
@@ -48,6 +48,7 @@ return [
     'tag tip' => 'Recommended options of production',
     'audit tip' => 'development bill should be audited before deploying',
     'ansible tip' => '',
+    'ansible hosts save error' => '{path}',
     'open tip' => "developer can't see this project while it is close",
 
     'group' => "Project's users",

--- a/messages/en/conf.php
+++ b/messages/en/conf.php
@@ -28,6 +28,7 @@ return [
     'tasks' => 'Advanced Tasks',
     'branch/tag' => 'Branch/Tag:',
     'enable audit' => 'Audit:',
+    'enable ansible' => 'Ansible: ',
     'enable open' => 'Enable:',
     'repo url tip' => 'git/svn. git url format:ssh-url, the ssh-key of the user of hosted server\'s php process should be add to git',
     'deploy from tip' => 'path for code in hosted server',
@@ -46,6 +47,7 @@ return [
     'branch tip' => 'Recommended options of test，maybe you would chose branch+commit',
     'tag tip' => 'Recommended options of production',
     'audit tip' => 'development bill should be audited before deploying',
+    'ansible tip' => '',
     'open tip' => "developer can't see this project while it is close",
 
     'group' => "Project's users",

--- a/messages/en/walle.php
+++ b/messages/en/walle.php
@@ -38,6 +38,7 @@ return [
     'hosted server ansible error' => 'hosted server error: please install ansible or disable ansible.',
     'target server error' => 'target server error: please make sure the ssh-key of user {local_user} of php process is added to target servers\'s user {remote_user}\'s authorized_keys, and {remote_user} have the access permission of {path} on target servers. error：{error}<br>',
     'target server sys error' => 'error happens when detecting on target servers：{error}<br>',
+    'target server ansible ping error' => 'ansible ping error',
     'unknown config' => 'unknown configuration',
     'you are not the manager' => 'you are not the manager',
     'get branches failed' => 'get branches failed：',

--- a/messages/en/walle.php
+++ b/messages/en/walle.php
@@ -35,6 +35,7 @@ return [
     'correct username passwd' => 'username and password is correct',
     'hosted server error' => 'hosted server error: please make sure the user {user} of php process have the access permission of {path}, and {ssh_passwd}. error：{error}<br>',
     'hosted server sys error' => 'error happens when detecting on hosted server：{error}<br>',
+    'hosted server ansible error' => 'hosted server error: please install ansible or disable ansible.',
     'target server error' => 'target server error: please make sure the ssh-key of user {local_user} of php process is added to target servers\'s user {remote_user}\'s authorized_keys, and {remote_user} have the access permission of {path} on target servers. error：{error}<br>',
     'target server sys error' => 'error happens when detecting on target servers：{error}<br>',
     'unknown config' => 'unknown configuration',

--- a/messages/zh/conf.php
+++ b/messages/zh/conf.php
@@ -28,6 +28,7 @@ return [
     'tasks' => '高级任务',
     'branch/tag' => '分支/tag上线:',
     'enable audit' => '是否开启审核:',
+    'enable ansible' => '是否开启Ansible:',
     'enable open' => '是否启用:',
     'repo url tip' => '支持git/svn。git格式:ssh-url，需要把宿主机php进程用户的ssh-key加入git信任',
     'deploy from tip' => '代码的检出存放路径',
@@ -46,6 +47,7 @@ return [
     'branch tip' => '测试环境推荐选项，可以选择branch+commit',
     'tag tip' => '生产环境推荐选项',
     'audit tip' => '开启时，用户提交上线任务需要审核方可上线',
+    'ansible tip' => '开启时，通过Ansible并发传输文件，加快多机器时的代码发布速度。需安装 ansible，详见文档',
     'open tip' => '关闭时，用户不能对此项目发起上线',
 
     'group' => '项目成员管理',

--- a/messages/zh/conf.php
+++ b/messages/zh/conf.php
@@ -49,6 +49,7 @@ return [
     'audit tip' => '开启时，用户提交上线任务需要审核方可上线',
     'ansible tip' => '开启时，通过Ansible并发传输文件，加快多机器时的代码发布速度。需安装 ansible，详见文档',
     'open tip' => '关闭时，用户不能对此项目发起上线',
+    'ansible hosts save error' => '无法保存 ansible hosts 文件，请确认 {path} 路径可写',
 
     'group' => '项目成员管理',
     'relation' => '用户组关系',

--- a/messages/zh/walle.php
+++ b/messages/zh/walle.php
@@ -35,6 +35,7 @@ return [
     'correct username passwd' => '用户名密码无误',
     'hosted server error' => '宿主机代码检出检测出错，请确认php进程用户{user}有代码存储仓库{path}读写权限，并且{ssh_passwd}。详细错误：{error}<br>',
     'hosted server sys error' => '宿主机检测时发生系统错误：{error}<br>',
+    'hosted server ansible error' => '宿主机未安装 ansible，请安装 ansible 或 在项目配置中关闭 ansible',
     'target server error' => '目标机器部署出错，请确认php进程{local_user}用户ssh-key加入目标机器的{remote_user}用户ssh-key信任列表，且{remote_user}有目标机器发布版本库{path}写入权限。详细错误：{error}<br>',
     'target server sys error' => '目标机检测时发生系统错误：{error}<br>',
     'unknown config' => '未知的配置',

--- a/messages/zh/walle.php
+++ b/messages/zh/walle.php
@@ -38,6 +38,7 @@ return [
     'hosted server ansible error' => '宿主机未安装 ansible，请安装 ansible 或 在项目配置中关闭 ansible',
     'target server error' => '目标机器部署出错，请确认php进程{local_user}用户ssh-key加入目标机器的{remote_user}用户ssh-key信任列表，且{remote_user}有目标机器发布版本库{path}写入权限。详细错误：{error}<br>',
     'target server sys error' => '目标机检测时发生系统错误：{error}<br>',
+    'target server ansible ping error' => '目标机 ansible ping 出错，请检查 ~/.ssh/config 及 ssh 证书配置',
     'unknown config' => '未知的配置',
     'you are not the manager' => '非管理员不能操作：（',
     'get branches failed' => '获取分支列表失败：',

--- a/migrations/m160307_082032_ansible.php
+++ b/migrations/m160307_082032_ansible.php
@@ -1,0 +1,33 @@
+<?php
+
+use app\models\Project;
+use yii\db\Migration;
+use yii\db\mssql\Schema;
+
+class m160307_082032_ansible extends Migration
+{
+    public function up()
+    {
+        $this->addColumn(Project::tableName(), 'ansible', Schema::TYPE_SMALLINT . '(3) NOT NULL DEFAULT 0 COMMENT "是否启用Ansible 0关闭，1开启" AFTER audit');
+
+    }
+
+    public function down()
+    {
+        $this->dropColumn(Project::tableName(), 'ansible');
+        echo "m160307_082032_ansible cannot be reverted.\n";
+
+        return true;
+    }
+
+    /*
+    // Use safeUp/safeDown to run migration code within a transaction
+    public function safeUp()
+    {
+    }
+
+    public function safeDown()
+    {
+    }
+    */
+}

--- a/models/Project.php
+++ b/models/Project.php
@@ -230,6 +230,15 @@ class Project extends \yii\db\ActiveRecord
     }
 
     /**
+     * 获取当前进程配置的ansible hosts文件路径
+     *
+     * @return string
+     */
+    public static function getAnsibleHostsFile() {
+        return sprintf('%s/ansible_hosts_project_%d', rtrim(yii::$app->params['ansible_hosts.dir'], '/'), static::$CONF->id);
+    }
+
+    /**
      * 添加数据保存事件afterSave
      *
      * @author wushuiyong

--- a/models/Project.php
+++ b/models/Project.php
@@ -185,6 +185,19 @@ class Project extends \yii\db\ActiveRecord
     }
 
     /**
+     * 获取 ansible 宿主机tar文件路径
+     *
+     * {deploy_from}/{env}/{project}-YYmmdd-HHiiss.tar.gz
+     *
+     * @param $version
+     * @return string
+     */
+    public static function getDeployPackagePath($version) {
+
+        return sprintf('%s.tar.gz', static::getDeployWorkspace($version));
+    }
+
+    /**
      * 拼接宿主机的仓库目录
      * {deploy_from}/{env}/{project}
      *
@@ -223,6 +236,18 @@ class Project extends \yii\db\ActiveRecord
     }
 
     /**
+     * 拼接目标机要发布的打包文件路径
+     * {release_library}/{project}/{version}.tar.gz
+     *
+     * @param string $version
+     * @return string
+     */
+    public static function getReleaseVersionPackage($version = '') {
+
+        return sprintf('%s.tar.gz', static::getReleaseVersionDir($version));
+    }
+
+    /**
      * 获取当前进程配置的目标机器host列表
      */
     public static function getHosts() {
@@ -240,6 +265,8 @@ class Project extends \yii\db\ActiveRecord
 
     /**
      * 获取当前进程配置的ansible hosts文件路径
+     *
+     * {ansible_hosts.dir}/ansible_hosts_project_{projectId}
      *
      * @return string
      */

--- a/models/Project.php
+++ b/models/Project.php
@@ -30,6 +30,7 @@ use yii\db\Expression;
  * @property string $repo_mode
  * @property string $repo_type
  * @property integer $audit
+ * @property integer $ansible
  * @property integer $keep_version_num
  */
 class Project extends \yii\db\ActiveRecord
@@ -97,7 +98,7 @@ class Project extends \yii\db\ActiveRecord
     {
         return [
             [['user_id', 'repo_url', 'name', 'level', 'deploy_from', 'release_user', 'release_to', 'release_library', 'hosts', 'keep_version_num'], 'required'],
-            [['user_id', 'level', 'status', 'audit', 'keep_version_num'], 'integer'],
+            [['user_id', 'level', 'status', 'audit', 'ansible', 'keep_version_num'], 'integer'],
             [['excludes', 'hosts', 'pre_deploy', 'post_deploy', 'pre_release', 'post_release'], 'string'],
             [['created_at', 'updated_at'], 'safe'],
             [['name', 'repo_password'], 'string', 'max' => 100],
@@ -115,28 +116,29 @@ class Project extends \yii\db\ActiveRecord
     public function attributeLabels()
     {
         return [
-            'id'              => 'ID',
-            'user_id'         => 'User ID',
-            'name'            => '项目名字',
-            'level'           => '环境级别',
-            'status'          => 'Status',
-            'version'         => 'Version',
-            'created_at'      => 'Created At',
-            'deploy_from'     => '检出仓库',
-            'excludes'        => '排除文件列表',
-            'release_user'    => '目标机器部署代码用户',
-            'release_to'      => '代码的webroot',
-            'release_library' => '发布版本库',
-            'hosts'           => '目标机器',
-            'pre_deploy'      => '宿主机代码检出前置任务',
-            'post_deploy'     => '宿主机同步前置任务',
-            'pre_release'     => '目标机更新版本前置任务',
-            'post_release'    => '目标机更新版本后置任务',
-            'repo_url'        => 'git/svn地址',
-            'repo_username'   => 'svn用户名',
-            'repo_password'   => 'svn密码',
-            'repo_mode'       => '分支/tag',
-            'audit'           => '任务需要审核？',
+            'id'               => 'ID',
+            'user_id'          => 'User ID',
+            'name'             => '项目名字',
+            'level'            => '环境级别',
+            'status'           => 'Status',
+            'version'          => 'Version',
+            'created_at'       => 'Created At',
+            'deploy_from'      => '检出仓库',
+            'excludes'         => '排除文件列表',
+            'release_user'     => '目标机器部署代码用户',
+            'release_to'       => '代码的webroot',
+            'release_library'  => '发布版本库',
+            'hosts'            => '目标机器',
+            'pre_deploy'       => '宿主机代码检出前置任务',
+            'post_deploy'      => '宿主机同步前置任务',
+            'pre_release'      => '目标机更新版本前置任务',
+            'post_release'     => '目标机更新版本后置任务',
+            'repo_url'         => 'git/svn地址',
+            'repo_username'    => 'svn用户名',
+            'repo_password'    => 'svn密码',
+            'repo_mode'        => '分支/tag',
+            'audit'            => '任务需要审核？',
+            'ansible'          => '开启Ansible？',
             'keep_version_num' => '线上版本保留数',
         ];
     }

--- a/models/Project.php
+++ b/models/Project.php
@@ -230,6 +230,15 @@ class Project extends \yii\db\ActiveRecord
     }
 
     /**
+     * 获取当前进程配置的ansible状态
+     *
+     * @return boolean
+     */
+    public static function getAnsibleStatus() {
+        return boolval(static::$CONF->ansible);
+    }
+
+    /**
      * 获取当前进程配置的ansible hosts文件路径
      *
      * @return string

--- a/models/Project.php
+++ b/models/Project.php
@@ -268,10 +268,14 @@ class Project extends \yii\db\ActiveRecord
      *
      * {ansible_hosts.dir}/project_{projectId}
      *
+     * @param integer $projectId 可以传入指定的id
      * @return string
      */
-    public static function getAnsibleHostsFile() {
-        return sprintf('%s/project_%d', rtrim(yii::$app->params['ansible_hosts.dir'], '/'), static::$CONF->id);
+    public static function getAnsibleHostsFile($projectId = 0) {
+        if (!$projectId) {
+            $projectId = static::$CONF->id;
+        }
+        return sprintf('%s/project_%d', rtrim(yii::$app->params['ansible_hosts.dir'], '/'), $projectId);
     }
 
     /**

--- a/models/Project.php
+++ b/models/Project.php
@@ -266,12 +266,12 @@ class Project extends \yii\db\ActiveRecord
     /**
      * 获取当前进程配置的ansible hosts文件路径
      *
-     * {ansible_hosts.dir}/ansible_hosts_project_{projectId}
+     * {ansible_hosts.dir}/project_{projectId}
      *
      * @return string
      */
     public static function getAnsibleHostsFile() {
-        return sprintf('%s/ansible_hosts_project_%d', rtrim(yii::$app->params['ansible_hosts.dir'], '/'), static::$CONF->id);
+        return sprintf('%s/project_%d', rtrim(yii::$app->params['ansible_hosts.dir'], '/'), static::$CONF->id);
     }
 
     /**

--- a/views/conf/edit.php
+++ b/views/conf/edit.php
@@ -283,6 +283,16 @@ use yii\widgets\ActiveForm;
         </div>
 
         <div class="form-group">
+            <label class="control-label bolder blue" for="form-field-2">
+                <?= yii::t('conf', 'enable ansible') ?>
+                <input name="Project[ansible]" value="0" type="hidden">
+                <input name="Project[ansible]" value="1" type="checkbox" <?= $conf->ansible ? 'checked' : '' ?>
+                       class="ace ace-switch ace-switch-5"  data-rel="tooltip" data-title="<?= yii::t('conf', 'ansible tip') ?>" data-placement="right">
+                <span class="lbl"></span>
+            </label>
+        </div>
+
+        <div class="form-group">
             <label class="control-label bolder blue">
                 <?= yii::t('conf', 'enable open') ?>
                 <input name="Project[status]" value="0" type="hidden">
@@ -291,6 +301,7 @@ use yii\widgets\ActiveForm;
                 <span class="lbl"></span>
             </label>
         </div>
+
       </div>
       <div class="box-footer">
         <input type="submit" class="btn btn-primary" value="<?= yii::t('w', 'submit') ?>">

--- a/views/conf/preview.php
+++ b/views/conf/preview.php
@@ -140,6 +140,14 @@ use yii\widgets\ActiveForm;
     </div>
 
     <div class="profile-info-row">
+        <div class="profile-info-name"> <?= yii::t('conf', 'enable ansible') ?> </div>
+
+        <div class="profile-info-value">
+            <span><?= \Yii::t('w', 'bool_' . $conf->ansible) ?></span>
+        </div>
+    </div>
+
+    <div class="profile-info-row">
         <div class="profile-info-name"> <?= yii::t('conf', 'enable open') ?> </div>
 
         <div class="profile-info-value">

--- a/views/walle/check.php
+++ b/views/walle/check.php
@@ -38,7 +38,7 @@ $this->title = yii::t('walle', 'md5 title');
         $('.get-md5').click(function() {
             $('.getting').show()
             $.get("<?= Url::to('@web/walle/file-md5?projectId=') ?>" + $("select[name=project]").val() + "&file=" + $('input[name=file]').val(), function(o) {
-                $('.md5-msg').text(o.data).show()
+                $('.md5-msg').html(o.data).show()
                 $('.getting').hide()
             });
         })


### PR DESCRIPTION
## 安装

1、宿主机安装 ansible

```
yum install ansible # RHEL/CentOS/Fedora

apt-get install ansible # Debian/Ubuntu

emerge -avt ansible  # Gentoo/Funtoo

pip install ansible # will also install  paramiko PyYAML jinja2
```

2、宿主机无需其他配置，兼容 ~/.ssh/config 名称、证书配置

3、目标机无需额外配置

## walle
1. 项目配置 中 开启Ansible
2. (可选) config/params.php 配置 ansible_hosts 文件存放路径
3. 按正常流程发布、上线代码，传输文件、远程执行命令均会通过ansible并发执行

## 测试效果
git 仓库 300M 左右的代码文件，php文件为主，包含很多 vendor
局域网内 14台目标机
反复对同一个版本，开关ansible支持，多次上线对比 start-deploy 接口总耗时

`关闭ansible: 平均每次 3分43秒`

`开启ansible: 平均每次 1分29秒`

## 存在问题
1、messages/en/conf.php 语言包不完善
2、svn 传输文件时，无论选择上线哪些文件，均会传输整个仓库目录中的文件
