### PR TITLE
svn env LC_ALL 设置问题

### DIFF
--- a/components/Svn.php
+++ b/components/Svn.php
@@ -232,6 +232,10 @@ class Svn extends Command {
      */
     public static function formatXmlLog($xmlString) {
         $history = [];
+        $pos = strpos($xmlString, '<?xml');
+        if ($pos > 0) {
+            $xmlString = substr($xmlString, $pos);
+        }
         $xml = simplexml_load_string($xmlString);
         foreach ($xml as $item) {
             $attr = $item->attributes();
@@ -300,7 +304,7 @@ class Svn extends Command {
      * @return string
      */
     private function _getSvnCmd($cmd) {
-        return sprintf('/usr/bin/env %s --username=%s --password=%s --non-interactive --trust-server-cert',
+        return sprintf('/usr/bin/env LC_ALL=C %s --username=%s --password=%s --non-interactive --trust-server-cert',
             $cmd, escapeshellarg($this->config->repo_username), escapeshellarg($this->config->repo_password));
     }
 


### PR DESCRIPTION
config/local.php 中设置了 putenv('LC_ALL=zh_CN.UTF-8');
但是我的ubuntu系统的env是 en_US.UTF-8

于是 svn 的所有命令都会输出如下警告
```
svn: warning: cannot set LC_CTYPE locale
svn: warning: environment variable LC_ALL is zh_CN.UTF-8
svn: warning: please check that your locale name is correct
```

导致获取 svn 历史记录，解析 xml 失败，提示
```
simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '<' not found
```

解决办法：
1、svn 命令设置 LC_ALL=C
2、xml解析查找以<?xml 开头

第一种解决方法，需要多测试下，是不是可行，中文注释会不会乱码之类的