### PR TITLE
fix: 当remote 删除当前分支后，刷新分支会失败

### DIFF
--- a/components/Git.php
+++ b/components/Git.php
@@ -67,8 +67,8 @@ class Git extends Command {
      */
     public function getBranchList() {
         $destination = Project::getDeployFromDir();
-        // 先更新，其实没有必要更新
-        ///$this->updateRepo('master', $destination);
+        // 应该先更新，不然在remote git删除当前选中的分支后，获取分支列表会失败
+        $this->updateRepo('master', $destination);
         $cmd[] = sprintf('cd %s ', $destination);
         $cmd[] = '/usr/bin/env git pull -a';
         $cmd[] = '/usr/bin/env git branch -a';

--- a/views/task/submit-git.php
+++ b/views/task/submit-git.php
@@ -88,6 +88,10 @@ use app\models\Project;
                 $('#branch').html(select);
                 $('.get-branch').hide();
                 $('.show-tip').show();
+                if(data.data.length == 1){                     
+                    $('#branch').change();
+                }
+
             });
         }
 


### PR DESCRIPTION
bug重现：

创建新分支 feature 分支，在feature分支上进行开发，将feature分支发布到测试线测试

当feature开发完成，合并到master分支，并且删除remote上的feature分支后，再对项目进行发布，会出现发布页面选中的依然是feature分支，并且刷新分支会失败