### PR TITLE
增加Docker镜像构建文件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:apache
+
+RUN apt-get update && apt-get install -y gettext-base libmcrypt-dev libicu-dev \
+      zlib1g-dev unzip git subversion ssh ansible && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install bcmath intl mbstring mcrypt mysqli opcache pdo_mysql
+RUN a2enmod rewrite
+
+COPY ./ /opt/walle-web
+COPY php.ini /usr/local/etc/php/conf.d/walle-web.ini
+COPY apache2.conf /etc/apache2/apache2.conf
+COPY entrypoint.sh /entrypoint.sh
+
+WORKDIR /opt/walle-web
+RUN curl -sS https://getcomposer.org/installer | php \
+      && mv composer.phar /usr/local/bin/composer \
+      && chmod +x /usr/local/bin/composer
+RUN composer install --prefer-dist --no-dev --optimize-autoloader -vvvv
+RUN chmod +x /entrypoint.sh && \
+    chown -R www-data:www-data /opt/walle-web
+
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/apache2.conf
+++ b/apache2.conf
@@ -1,0 +1,51 @@
+Mutex file:/var/lock/apache2 default
+PidFile /var/run/apache2/apache2.pid
+Timeout 300
+KeepAlive On
+MaxKeepAliveRequests 100
+KeepAliveTimeout 5
+User www-data
+Group www-data
+HostnameLookups Off
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+Listen 80
+
+<Directory />
+	Options FollowSymLinks
+	AllowOverride None
+	Require all denied
+</Directory>
+
+<Directory /opt/walle-web/web/>
+	AllowOverride All
+	Require all granted
+</Directory>
+
+DocumentRoot /opt/walle-web/web
+
+AccessFileName .htaccess
+<FilesMatch "^\.ht">
+	Require all denied
+</FilesMatch>
+
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+CustomLog /proc/self/fd/1 combined
+
+<FilesMatch \.php$>
+	SetHandler application/x-httpd-php
+</FilesMatch>
+
+DirectoryIndex index.php index.html
+
+IncludeOptional conf-enabled/*.conf
+IncludeOptional sites-enabled/*.conf

--- a/config/local.php
+++ b/config/local.php
@@ -12,27 +12,28 @@ putenv('LC_ALL=zh_CN.UTF-8');
 return [
     'components' => [
         'db' => [
-            'dsn'       => 'mysql:host=127.0.0.1;dbname=walle',
-            'username'  => 'root',
-            'password'  => '',
+            'dsn'       => isset($_ENV['WALLE_DB_DSN'])  ? $_ENV['WALLE_DB_DSN']  : 'mysql:host=127.0.0.1;dbname=walle',
+            'username'  => isset($_ENV['WALLE_DB_USER']) ? $_ENV['WALLE_DB_USER'] : 'root',
+            'password'  => isset($_ENV['WALLE_DB_PASS']) ? $_ENV['WALLE_DB_PASS'] : '',
         ],
         'mail' => [
             'transport' => [
-                'host'       => 'smtp.exmail.qq.com',     # smtp 发件地址
-                'username'   => 'service@huamanshu.com',  # smtp 发件用户名
-                'password'   => 'K84erUuxg1bHqrfD',       # smtp 发件人的密码
-                'port'       => 25,                       # smtp 端口
-                'encryption' => 'tls',                    # smtp 协议
+                'host'       => isset($_ENV['WALLE_MAIL_HOST']) ? $_ENV['WALLE_MAIL_HOST'] : 'smtp.exmail.qq.com',     # smtp 发件地址
+                'username'   => isset($_ENV['WALLE_MAIL_USER']) ? $_ENV['WALLE_MAIL_USER'] : 'service@huamanshu.com',  # smtp 发件用户名
+                'password'   => isset($_ENV['WALLE_MAIL_PASS']) ? $_ENV['WALLE_MAIL_PASS'] : 'K84erUuxg1bHqrfD',       # smtp 发件人的密码
+                'port'       => isset($_ENV['WALLE_MAIL_PORT']) ? $_ENV['WALLE_MAIL_PORT'] : 25,                       # smtp 端口
+                'encryption' => isset($_ENV['WALLE_MAIL_ENCRYPTION']) ? $_ENV['WALLE_MAIL_ENCRYPTION'] : 'tls',                    # smtp 协议
             ],
             'messageConfig' => [
                 'charset' => 'UTF-8',
-                'from'    => ['service@huamanshu.com' => '花满树出品'],  # smtp 发件用户名(须与mail.transport.username一致)
+                'from'    => [
+                  (isset($_ENV['WALLE_MAIL_EMAIL']) ? $_ENV['WALLE_MAIL_EMAIL'] : 'service@huamanshu.com') => (isset($_ENV['WALLE_MAIL_NAME']) ? $_ENV['WALLE_MAIL_NAME'] : '花满树出品'),
+                ],  # smtp 发件用户名(须与mail.transport.username一致)
             ],
         ],
         'request' => [
             'cookieValidationKey' => 'PdXWDAfV5-gPJJWRar5sEN71DN0JcDRV',
         ],
     ],
-    'language'   => 'zh-CN', // zh-CN => 中文,  en => English
+    'language'   => isset($_ENV['WALLE_LANGUAGE']) ? $_ENV['WALLE_LANGUAGE'] : 'zh-CN', // zh-CN => 中文,  en => English
 ];
-

--- a/config/params.php
+++ b/config/params.php
@@ -14,9 +14,9 @@ return [
     ],
 
     // *******操作日志目录*******
-    'log.dir' => '/tmp/walle/',
+    'log.dir' => isset($_ENV['WALLE_LOG_PATH']) ? $_ENV['WALLE_LOG_PATH'] : '/tmp/walle/',
     // *******Ansible Hosts 主机列表目录*******
-    'ansible_hosts.dir' => realpath(__DIR__ . '/../runtime') . '/ansible_hosts/',
+    'ansible_hosts.dir' => isset($_ENV['WALLE_ANSIBLE_HOSTS_DIR']) ? $_ENV['WALLE_ANSIBLE_HOSTS_DIR'] : realpath(__DIR__ . '/../runtime') . '/ansible_hosts/',
     // *******指定公司邮箱后缀*******
     'mail-suffix' => [
         '*', # 支持多个

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+./yii walle/setup --interactive=0
+
+exec $@

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,6 @@
+[PHP]
+display_errors = On
+short_open_tag = Off
+
+[Date]
+date.timezone = Asia/Shanghai


### PR DESCRIPTION
增加增加Docker镜像构建文件，可以构建Docker镜像。

配置信息通过以下环境变量设置：

`WALLE_DB_DSN` - 数据库DSN
`WALLE_DB_USER` - 数据库用户名
`WALLE_DB_PASS` - 数据库密码
`WALLE_MAIL_HOST` - 邮件服务器
`WALLE_MAIL_USER` - 邮件用户名
`WALLE_MAIL_PASS` - 邮件密码
`WALLE_MAIL_PORT` - 邮件端口
`WALLE_MAIL_ENCRYPTION` - 邮件加密方式
`WALLE_MAIL_EMAIL` - 邮件地址
`WALLE_LANGUAGE` - 语言
`WALLE_LOG_PATH` - 日志目录
`WALLE_ANSIBLE_HOSTS_DIR` - Ansible Hosts 主机列表目录

我在[https://hub.docker.com/r/starlight36/walle-web/](https://hub.docker.com/r/starlight36/walle-web/)上做了一个镜像，可以通过这个docker-compose.yml使用。

```yml
walle:
  image: starlight36/walle-web
  environment:
    - "WALLE_DB_DSN=mysql:host=localhost;dbname=walle_production"
    - "WALLE_DB_USER=walle"
    - "WALLE_DB_PASS=walle"
  ports:
    - "80:80"
  restart: always
```