### PR TITLE
更正提示目录

### DIFF
--- a/controllers/WalleController.php
+++ b/controllers/WalleController.php
@@ -223,7 +223,7 @@ class WalleController extends Controller {
                 $code = -1;
                 $log[] = yii::t('walle', 'target server is not writable error', [
                     'remote_user' => $project->release_user,
-                    'path'        => $project->release_to,
+                    'path'        => $project->release_library,
                 ]);
             }
 


### PR DESCRIPTION
错误提示里的目录要跟前面`Project::getReleaseVersionDir()`中用来测试权限的目录对应上。