### PR TITLE
[修改]项目配置页面，上线单页面操作按钮小分辨率也支持显示

### DIFF
--- a/views/conf/index.php
+++ b/views/conf/index.php
@@ -45,7 +45,7 @@ use yii\helpers\Url;
                     <td><?= \Yii::t('w', 'conf_audit_' . $item['audit']) ?></td>
                     <td><?= \Yii::t('w', 'conf_status_' . $item['status']) ?></td>
                     <td class="<?= \Yii::t('w', 'conf_status_' . $item['status'] . '_color') ?>">
-                        <div class="visible-md visible-lg hidden-sm hidden-xs action-buttons">
+                        <div class="action-buttons">
                             <a href="<?= Url::to("@web/conf/preview/?projectId={$item['id']}") ?>" data-toggle="modal" data-target="#myModal">
                                 <i class="icon-zoom-in bigger-130"></i>
                                 <?= yii::t('conf', 'p_preview') ?>

--- a/views/task/list.php
+++ b/views/task/list.php
@@ -56,7 +56,7 @@ use yii\helpers\Url;
                 <td class="<?= \Yii::t('w', 'task_status_' . $item['status'] . '_color') ?>">
                     <?= \Yii::t('w', 'task_status_' . $item['status']) ?></td>
                 <td>
-                    <div class="visible-md visible-lg hidden-sm hidden-xs action-buttons">
+                    <div class="action-buttons">
                     <?php if ($audit && !in_array($item['status'],[Task::STATUS_DONE, Task::STATUS_FAILED])) { ?>
                         <label>
                             <input class="ace ace-switch ace-switch-5 task-operation"


### PR DESCRIPTION
在小分辨率下。那些操作按钮都无法显示。所以直接去掉这几个css