### PR TITLE
fixed:多次回滚后， 显示不了当前版本标记

### DIFF
--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -52,8 +52,9 @@ class TaskController extends Controller {
     /**
      * 提交任务
      *
-     * @param $projectId 没有projectId则显示列表
+     * @param integer $projectId 没有projectId则显示列表
      * @return string
+     * @throws
      */
     public function actionSubmit($projectId = null) {
 
@@ -157,6 +158,7 @@ class TaskController extends Controller {
 
         $rollbackTask = new Task();
         $rollbackTask->attributes = $this->task->attributes;
+        $rollbackTask->commit_id = $this->task->getRollbackCommitId();
         $rollbackTask->status = $status;
         $rollbackTask->action = Task::ACTION_ROLLBACK;
         $rollbackTask->link_id = $this->task->ex_link_id;

--- a/models/Task.php
+++ b/models/Task.php
@@ -2,7 +2,6 @@
 
 namespace app\models;
 
-use Yii;
 use yii\behaviors\TimestampBehavior;
 use yii\db\Expression;
 use app\components\GlobalHelper;
@@ -183,6 +182,15 @@ class Task extends \yii\db\ActiveRecord
         } else {
             throw new \InvalidArgumentException('file list empty');
         }
+    }
+
+    /**
+     * 取得回滚的当前commit_id
+     * @return bool|string
+     */
+    public function getRollbackCommitId()
+    {
+        return $this->ex_link_id ? static::find()->where(['link_id'=>$this->ex_link_id])->orderBy(['id'=>SORT_ASC])->select('commit_id')->scalar():'';
     }
 
 }


### PR DESCRIPTION
回滚时生成数据记录的commit_id为回滚数据行的commit_id, 并不是当前版本的commit_id。导致列表页看到的commit_id并不是当前线上版本的commit_id，不方便查看。