### PR TITLE
fixbug#317 发布目录不用git仓库名称，改成project_id

### DIFF
--- a/components/Folder.php
+++ b/components/Folder.php
@@ -264,7 +264,8 @@ class Folder extends Ansible {
     public function getLinkCommand($version) {
         $user = $this->config->release_user;
         $project = Project::getGitProjectName($this->getConfig()->repo_url);
-        $currentTmp = sprintf('%s/%s/current-%s.tmp', rtrim($this->getConfig()->release_library, '/'), $project, $project);
+        //发布目录不用git仓库名称，改成project_id
+        $currentTmp = sprintf('%s/%s/current-%s.tmp', rtrim($this->getConfig()->release_library, '/'), $this->getConfig()->id, $project);
         // 遇到回滚，则使用回滚的版本version
         $linkFrom = Project::getReleaseVersionDir($version);
         $cmd[] = sprintf('ln -sfn %s %s', $linkFrom, $currentTmp);

--- a/models/Project.php
+++ b/models/Project.php
@@ -255,14 +255,14 @@ class Project extends \yii\db\ActiveRecord
 
     /**
      * 拼接目标机要发布的目录
-     * {release_library}/{project}/{version}
+     * {release_library}/{project_id}/{version}
      *
      * @param $version
      * @return string
      */
     public static function getReleaseVersionDir($version = '') {
         return sprintf('%s/%s/%s', rtrim(static::$CONF->release_library, '/'),
-            static::getGitProjectName(static::$CONF->repo_url), $version);
+                static::$CONF->id,$version);
     }
 
     /**


### PR DESCRIPTION
 发布目录不用git仓库名称