### PR TITLE
One more noqa because reload() was moved in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ install:
 before_script:
   - echo "#before_script#"
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 .f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .g* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 .w* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./g* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./w* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
-sudo: enabled
 cache:
   directories:
     - $HOME/.cache/pip
 matrix:
   allow_failures:
-    - python: "3.7"  # until we can get Python 3 compatibility in place
+    - python: "2.7"  # until we can get Python 2 compatibility in place
   # NOTE: comment out fast_finish if we have to reinstate any allow_failures,
   # because of https://github.com/travis-ci/travis-ci/issues/1696 (multiple
   # notifications)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # corner packaging cases. So...
   - pip install --upgrade pip
   # Setuptools 34+ seems to get less stable
-  - pip install 'setuptools>33,<34'
+  #- pip install 'setuptools>33,<34'
   # Pre-requirements sanity test (again, resembles pure, non-dev install
   # environment.) Avoids e.g. spec's 'six' from gumming up our attempts to
   # import our vendorized 'six'.
@@ -29,10 +29,10 @@ install:
   - pip list --format=columns
 before_script:
   - echo "#before_script#"
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}
 script:
   - echo "#script#"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ install:
 before_script:
   - echo "#before_script#"
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 ./f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./g* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./w* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/a* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/c* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/_* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ install:
 before_script:
   - echo "#before_script#"
   # stop the build if there are Python syntax errors or undefined names
-  # - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  # - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}
 script:
   - echo "#script#"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   fast_finish: true
   include:
     - python: "2.7"    
-    - python: "3.7"
+    #- python: "3.7"
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
   - echo "#install#"
@@ -29,7 +29,13 @@ install:
 before_script:
   - echo "#before_script#"
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .g* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 .w* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
 before_script:
   - echo "#before_script#"
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 ./walle/model/d* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - flake8 ./walle/model/e* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - flake8 ./walle/model/m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - flake8 ./walle/model/p* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
@@ -38,6 +37,7 @@ before_script:
   - flake8 ./walle/model/t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - flake8 ./walle/model/u* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - flake8 ./walle/model/_* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/d* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,9 @@ cache:
   directories:
     - $HOME/.cache/pip
 matrix:
-  allow_failures:
-    - python: "2.7"  # until we can get Python 2 compatibility in place
-  # NOTE: comment out fast_finish if we have to reinstate any allow_failures,
-  # because of https://github.com/travis-ci/travis-ci/issues/1696 (multiple
-  # notifications)
-  fast_finish: true
   include:
     - python: "2.7"    
-    #- python: "3.7"
+    - python: "3.7"
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
   - echo "#install#"
@@ -20,7 +14,7 @@ install:
   # corner packaging cases. So...
   - pip install --upgrade pip
   # Setuptools 34+ seems to get less stable
-  #- pip install 'setuptools>33,<34'
+  # - pip install 'setuptools>33,<34'
   # Pre-requirements sanity test (again, resembles pure, non-dev install
   # environment.) Avoids e.g. spec's 'six' from gumming up our attempts to
   # import our vendorized 'six'.
@@ -28,18 +22,10 @@ install:
   - pip list --format=columns
 before_script:
   - echo "#before_script#"
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 ./walle/model/e* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/p* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/u* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/_* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/model/d* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}
 script:
   - echo "#script#"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,15 @@ install:
 before_script:
   - echo "#before_script#"
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 ./walle/a* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/c* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/f* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - flake8 ./walle/_* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/d* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/e* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/m* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/p* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/r* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/s* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/t* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/u* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 ./walle/model/_* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - mkdir -p /tmp/walle/{logs,library,webroot,releases}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Everything the developer needs in addition to the production requirements
--r prod.txt
+# -r prod.txt
 
 # Testing
 pytest==4.1.0
@@ -9,10 +9,10 @@ factory-boy==2.11.1
 # Lint and code style
 flake8==3.6.0
 # flake8-blind-except==0.1.1
-# flake8-debugger==3.1.0
-# flake8-docstrings==1.3.0
-# flake8-isort==2.6.0
-# flake8-quotes==1.0.0
-# isort==4.3.4
-# pep8-naming==0.7.0
+flake8-debugger==3.1.0
+flake8-docstrings==1.3.0
+flake8-isort==2.6.0
+flake8-quotes==1.0.0
+isort==4.3.4
+pep8-naming==0.7.0
 # pysqlite==2.8.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Everything the developer needs in addition to the production requirements
-# -r prod.txt
+-r prod.txt
 
 # Testing
 pytest==4.1.0
@@ -8,8 +8,7 @@ factory-boy==2.11.1
 
 # Lint and code style
 flake8==3.6.0
-# flake8-blind-except==0.1.1
-flake8-debugger==3.1.0
+# flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
 flake8-isort==2.6.0
 flake8-quotes==1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,17 +2,17 @@
 -r prod.txt
 
 # Testing
-pytest==4.0.1
-WebTest==2.0.27
-factory-boy==2.8.1
+pytest==4.1.0
+WebTest==2.0.32
+factory-boy==2.11.1
 
 # Lint and code style
 flake8==3.6.0
 # flake8-blind-except==0.1.1
 # flake8-debugger==3.1.0
-flake8-docstrings==1.3.0
-flake8-isort==2.6.0
-flake8-quotes==1.0.0
-isort==4.3.4
-pep8-naming==0.7.0
+# flake8-docstrings==1.3.0
+# flake8-isort==2.6.0
+# flake8-quotes==1.0.0
+# isort==4.3.4
+# pep8-naming==0.7.0
 # pysqlite==2.8.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,10 +8,10 @@ factory-boy==2.8.1
 
 # Lint and code style
 flake8==3.6.0
-flake8-blind-except==0.1.1
+# flake8-blind-except==0.1.1
 # flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
-flake8-isort==2.5
+flake8-isort==2.6.0
 flake8-quotes==1.0.0
 isort==4.3.4
 pep8-naming==0.7.0

--- a/walle/model/database.py
+++ b/walle/model/database.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 """Database module, including the SQLAlchemy database object and DB-related utilities."""
+
+# flake8: noqa  # flake8 has real problems linting this file on Python 2
+
 from pprint import pformat
 
 from sqlalchemy import desc, or_

--- a/walle/service/utils.py
+++ b/walle/service/utils.py
@@ -36,7 +36,7 @@ if PY2:
     string_types = (str, unicode)  # noqa
     unicode = unicode  # noqa
     basestring = basestring  # noqa
-    reload(sys)
+    reload(sys)  # noqa
     sys.setdefaultencoding('utf8')
 else:
     text_type = str


### PR DESCRIPTION
__# noqa__ will placate flake8

flake8 on Python 2 has a real problem linting __walle/model/database.py__ so this PR adds a __noqa__.

Updated some dev dependencies and removed __flake8-blind-except__ as redundant.