### PR TITLE
修复在python3.6环境下, 启动flask_socketio报错的问题

### DIFF
--- a/walle/app.py
+++ b/walle/app.py
@@ -185,7 +185,7 @@ def register_socketio(app):
         return app
     socketio.init_app(app, async_mode='gevent')
     socketio.on_namespace(WalleSocketIO(namespace='/walle'))
-    socketio.run(app, debug=True, host=app.config.get('HOST'), port=app.config.get('PORT'))
+    socketio.run(app, debug=app.config.get('DEBUG'), host=app.config.get('HOST'), port=app.config.get('PORT'))
     return app
 
 


### PR DESCRIPTION
socketio.run 这个方法假如传入debug=True的话, 在python3.6环境下跑, 启动的时候会报一个 MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6
这个错误会影响实际的使用, 所以至少生产环境版本应该把这个DEBUG设置为false