### PR TITLE
change rollback task name

### DIFF
--- a/walle/api/task.py
+++ b/walle/api/task.py
@@ -155,7 +155,7 @@ class TaskAPI(SecurityResource):
             raise WalleError(code=Code.rollback_error)
 
         task['id'] = None
-        task['name'] = task['name'] + ' - 回滚此次上线'
+        task['name'] = task['name'] + '-回滚此次上线'
         task['link_id'] = task['ex_link_id']
         task['ex_link_id'] = ''
         task['is_rollback'] = 1


### PR DESCRIPTION
fix the error when rollback by remove blank in task name:
bash: line 0: export: `-': not a valid identifier
bash: line 0: export: `回滚此次上线': not a valid identifier