### PR TITLE
2.1/bugfix/创建软链失败

### DIFF
--- a/walle/service/deployer.py
+++ b/walle/service/deployer.py
@@ -277,9 +277,9 @@ class Deployer:
             self.previous_release_version = os.path.basename(result.stdout).strip()
 
             # 1. create a tmp link dir
-            current_link_tmp_dir = '%s/current-tmp-%s' % (self.project_info['target_releases'], self.task_id)
-            command = 'ln -sfn %s/%s %s' % (
-                self.project_info['target_releases'], self.release_version, current_link_tmp_dir)
+            current_link_tmp_dir = 'current-tmp-%s' % (self.task_id)
+            command = 'ln -sfn %s %s' % (
+                self.release_version, current_link_tmp_dir)
             result = waller.run(command, wenv=self.config())
 
             # 2. make a soft link from release to tmp link

--- a/walle/service/git/repo.py
+++ b/walle/service/git/repo.py
@@ -166,13 +166,13 @@ class Repo:
 
     def tags(self):
         '''
-        获取所有tag
+        获取所有tag，按时间倒序
 
         @param branch:
         @param kwargs:
         @return:
         '''
-        return [str(tag) for tag in PyRepo(self.path).tags]
+        return [str(tag) for tag in PyRepo(self.path).tags][-10:]
 
     def commits(self, branch):
         '''


### PR DESCRIPTION
这个分析判断是路径错误，因为先cd进了target_releases目录，然后在创建软链时的相对路径又使用了target_releases目录。
但是只有一个人提了Issues，需要再验证。