### PR TITLE
解决 项目管理 》成员管理 添加成员 失败的bug

### DIFF
--- a/walle/model/member.py
+++ b/walle/model/member.py
@@ -202,7 +202,7 @@ class MemberModel(SurrogatePK, Model):
 
         count = query.count()
         query = query.order_by(MemberModel.id.asc())
-        if size:
+        if size and size>0:
             query = query.offset(int(size) * int(page)).limit(size)
         data = query.all()
 


### PR DESCRIPTION
sqlalchemy.exc.ProgrammingError: (_mysql_exceptions.ProgrammingError) (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1' at line 2") [SQL: 'SELECT users.id AS users_id, users.username AS users_username, users.is_email_verified AS users_is_email_verified, users.email AS users_email, users.password AS users_password, users.avatar AS users_avatar, users.`role` AS users_role, users.status AS users_status, users.last_space AS users_last_space, users.created_at AS users_created_at, users.updated_at AS users_updated_at, members.access_level AS members_access_level FROM users INNER JOIN members ON users.id = members.user_id WHERE users.status NOT IN (%s) AND members.source_id = %s AND members.source_type = %s ORDER BY members.id ASC  LIMIT %s, %s'] [parameters: (-1, 1, 'group', 0, -1)] (Background on this error at: http://sqlalche.me/e/f405)