### PR TITLE
让 flask 的 web 服务以多线程的方式启动。

### DIFF
--- a/walle/app.py
+++ b/walle/app.py
@@ -6,6 +6,8 @@ gevent.monkey.patch_all()
 import logging
 import sys
 import os
+import threading
+
 from flask import Flask, render_template, current_app
 from flask_restful import Api
 from walle import commands
@@ -187,7 +189,9 @@ def register_socketio(app):
         return app
     socketio.init_app(app, async_mode='gevent')
     socketio.on_namespace(WalleSocketIO(namespace='/walle'))
-    socketio.run(app, debug=app.config.get('DEBUG'), host=app.config.get('HOST'), port=app.config.get('PORT'))
+    socket_args = {"debug": app.config.get('DEBUG'), "host": app.config.get('HOST'), "port": app.config.get('PORT')}
+    socket_thread = threading.Thread(target=socketio.run, name="socket_thread", args=(app, ), kwargs=socket_args)
+    socket_thread.start()
     return app
 
 


### PR DESCRIPTION
让 flask 的 web 服务以多线程的方式启动。让主线程继续执行启动  socket 后的逻辑（否则主线程会在启动 socketio 这里一直阻塞，后续的逻辑是不会被执行的）。