### PR TITLE
修复bug，未分配用户登录的时候，前端提示服务器错误。改为提示具体的错误信息。

### DIFF
--- a/walle/api/passport.py
+++ b/walle/api/passport.py
@@ -16,6 +16,8 @@ from walle.api.api import ApiResource
 from walle.form.user import LoginForm
 from walle.model.user import UserModel
 from walle.service.code import Code
+from walle.service.error import WalleError
+
 
 class PassportAPI(ApiResource):
     actions = ['login', 'logout']
@@ -46,8 +48,11 @@ class PassportAPI(ApiResource):
             user = UserModel.query.filter_by(email=form.email.data).first()
 
             if user is not None and user.verify_password(form.password.data):
-                login_user(user)
-                user.fresh_session()
+                try:
+                    login_user(user)
+                    user.fresh_session()
+                except WalleError as e:
+                    return self.render_json(code=e.code, data=Code.code_msg[e.code])
                 return self.render_json(data=current_user.to_json())
 
         return self.render_json(code=Code.error_pwd, data=form.errors)


### PR DESCRIPTION
收集错误信息，然后返回给前端。