### PR TITLE
修复 bug：#824。超级管理员给某个空间赋值给某个用户后，members 表中的数据没有及时更新导致此用户仍然不属于此空间。

### DIFF
--- a/walle/api/space.py
+++ b/walle/api/space.py
@@ -125,16 +125,22 @@ class SpaceAPI(SecurityResource):
             space = SpaceModel().get_by_id(space_id)
             data = form.form2dict()
             current_app.logger.info(data)
-
+            member_model = MemberModel(group_id=space_id)
+            old_owner = space.user_id
+            new_owner = data['user_id']
             # a new type to update a model
-            ret = space.update(data)
+            space.update(data)
+
+            if str(old_owner) != str(new_owner):
+                # owner has changed
+                member_model.change_owner(old_owner, new_owner)
+
             # create group
-            member = {"user_id": data['user_id'], "role": OWNER}
-            members = []
+            current_owner = {"user_id": new_owner, "role": OWNER}
             if 'members' in request.form:
                 members = json.loads(request.form['members'])
-                members.append(member)
-                MemberModel(group_id=space_id).update_group(members=members)
+                members.append(current_owner)
+                member_model.update_group(members=members)
             return self.render_json(data=space.item())
         else:
             return self.render_error(code=Code.form_error, message=form.errors)


### PR DESCRIPTION
bug:https://github.com/meolu/walle-web/issues/824
bug 原因：超级管理员给某个空间赋值给某个用户后，members 表中的数据没有及时更新导致此用户仍然不属于此空间。
修复：在更新 space 的时候，判断一下新旧的 owner，如果有差异的话，先将 owner 更新一下。