### PR TITLE
添加cookie配置

### DIFF
--- a/walle/api/api.py
+++ b/walle/api/api.py
@@ -73,6 +73,7 @@ class SecurityResource(ApiResource):
 
     def __init__(self):
         if current_user.is_authenticated:
+            current_user.fresh_session()
             self.space_id = None if current_user.role == SUPER else session['space_id']
 
     # @login_required

--- a/walle/api/passport.py
+++ b/walle/api/passport.py
@@ -18,7 +18,6 @@ from walle.model.user import UserModel
 from walle.service.code import Code
 from walle.service.error import WalleError
 
-
 class PassportAPI(ApiResource):
     actions = ['login', 'logout']
 
@@ -49,7 +48,11 @@ class PassportAPI(ApiResource):
 
             if user is not None and user.verify_password(form.password.data):
                 try:
-                    login_user(user)
+                    remember = False
+                    if current_app.config.get("COOKIE_ENABLE"):
+                        remember = True
+                    current_app.logger.info("remember me(记住我)功能是否开启,{}".format(remember))
+                    login_user(user, remember=remember)
                     user.fresh_session()
                 except WalleError as e:
                     return self.render_json(code=e.code, data=Code.code_msg[e.code])

--- a/walle/config/settings.py
+++ b/walle/config/settings.py
@@ -49,3 +49,6 @@ class Config(object):
     # 轮转数量是 10 个
     LOG_FILE_BACKUP_COUNT = 10
     LOG_FORMAT = "%(asctime)s %(thread)d %(message)s"
+
+    # 登录cookie 防止退出浏览器重新登录
+    COOKIE_ENABLE = False

--- a/walle/config/settings_dev.py
+++ b/walle/config/settings_dev.py
@@ -33,3 +33,6 @@ class DevConfig(Config):
     CODE_BASE = '/tmp/walle/codebase/'
 
     SQLALCHEMY_ECHO = True
+
+    # 登录cookie 防止退出浏览器重新登录
+    COOKIE_ENABLE = False

--- a/walle/config/settings_prod.py
+++ b/walle/config/settings_prod.py
@@ -49,3 +49,6 @@ class ProdConfig(Config):
     MAIL_DEFAULT_SENDER = 'service@walle-web.io'
     MAIL_USERNAME = 'service@walle-web.io'
     MAIL_PASSWORD = 'Ki9y&3U82'
+
+    # 登录cookie 防止退出浏览器重新登录
+    COOKIE_ENABLE = False

--- a/walle/config/settings_test.py
+++ b/walle/config/settings_test.py
@@ -32,3 +32,6 @@ class TestConfig(Config):
 
     # 本地代码检出路径（用户查询分支, 编译, 打包） #TODO
     CODE_BASE = '/tmp/walle/codebase/'
+
+    # 登录cookie 防止退出浏览器重新登录
+    COOKIE_ENABLE = True


### PR DESCRIPTION
添加cookie配置，减少浏览器退出时需要重输密码次数。
core: use "remember = True" config on flask_login package.
测试时发现在SecurityResource中需要fresh_session,之前这一步操作是在login中完成的。
测试环境连不上，无法进行测试环境测试。
这里没有进行过期时间配置，默认是365天。可以在配置文件中选择开启。