### PR TITLE
更新 pytz 依赖版本，避免初始化时的错误

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -38,6 +38,6 @@ Flask-Bcrypt==0.7.1
 anyjson==0.3.3
 celery==3.1.18
 pycrypto==2.6.1
-pytz==2015.6
+pytz==2015.7
 requests==2.20.0
 GitPython==2.1.11


### PR DESCRIPTION
Fix ERROR: babel 2.7.0 has requirement pytz>=2015.7, but you'll have pytz 2015.6 which is incompatible.