### PR TITLE
优化代码错误提示

### DIFF
--- a/walle/service/websocket.py
+++ b/walle/service/websocket.py
@@ -62,7 +62,7 @@ class WalleSocketIO(Namespace):
             branches = wi.list_branch()
             emit('branches', {'event': 'branches', 'data': branches}, room=self.room)
         except Exception as e:
-            emit('branches', {'event': 'error', 'data': {'message': e.message}}, room=self.room)
+            emit('branches', {'event': 'error', 'data': {'message': e.message or str(e)}}, room=self.room)
 
     def on_tags(self, message=None):
         wi = Deployer(project_id=self.room)


### PR DESCRIPTION
部分情况下（比如 git 权限不对）选取项目分支报错的时候 e.message 为空字符串，这样改动能明显地看到执行的git命令和它的错误提示，极大地方便排错