### PR TITLE
解决 已克隆项目切换到tag后下次初始化仓库直接git pull 报错问题。

### DIFF
--- a/walle/service/git/repo.py
+++ b/walle/service/git/repo.py
@@ -89,12 +89,13 @@ class Repo:
                 return False
         return False
 
-    def init(self, url):
+    def init(self, url, branch="master"):
         # 创建目录
         if not os.path.exists(self.path):
             os.makedirs(self.path)
         # git clone
         if self.is_git_dir():
+            self.checkout_2_branch(branch)
             return self.pull()
         else:
             return self.clone(url)


### PR DESCRIPTION
```
>>git checkout tag-xxx
>>git pull
```
```
You are not currently on a branch. Please specify which
branch you want to merge with. See git-pull(1) for details.
git pull <remote> <branch>
```